### PR TITLE
Add functionality to disable Windows Explorer menu pin

### DIFF
--- a/run.py
+++ b/run.py
@@ -101,8 +101,9 @@ class MainFrame(wx.Frame):
         self.ipbox = wx.CheckBox(panel, label="Block tracking IP addresses", pos=(10, 85))
         self.ipbox.SetToolTip(wx.ToolTip("Blocks known tracking IP addresses with Windows Firewall."))
 
+        # OneDrive uninstall checkbox
         self.onedrivedbox = wx.CheckBox(panel, label="Uninstall OneDrive", pos=(10, 115))
-        self.onedrivedbox.SetToolTip(wx.ToolTip("Uninstalls OneDrive from your computer."))
+        self.onedrivedbox.SetToolTip(wx.ToolTip("Uninstalls OneDrive from your computer and removes OneDrive from explorer."))
 
         # Service radio box
         self.serviceradbox = wx.RadioBox(panel, label="Service Method", pos=(135, 5), choices=["Disable", "Delete"])
@@ -421,6 +422,8 @@ def modifyserviceregs(dwordval):
 
 def modifyonedrive(type):
     onedrivepath = r'SOFTWARE\Wow6432Node\Policies\Microsoft\Windows\OneDrive'  # Path to OneDrive key
+    odxpath32 = r'HKEY_CLASSES_ROOT\CLSID\{018D5C66-4533-4307-9B53-224DE2ED1FE6}' # Path to 32-bit Key
+    odxpath64 = r'HKEY_CLASSES_ROOT\Wow6432Node\CLSID\{018D5C66-4533-4307-9B53-224DE2ED1FE6}' # Path to 64-bit Key
 
     try:
         onedrivekey = _winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE, onedrivepath, 0, _winreg.KEY_ALL_ACCESS)
@@ -428,7 +431,23 @@ def modifyonedrive(type):
         _winreg.CloseKey(onedrivekey)
         print "OneDrive key succesfully modified."
     except (WindowsError, IOError):
-        print "Unable to modify OneDrive key. Deleted, or is the program not elevated?"
+        print "Unable to modify OneDrive FileSync key. Deleted, or is the program not elevated?"
+        
+    try:
+        odxkey32 = _winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE, odxkey32, 0, _winreg.KEY_ALL_ACCESS)
+        _winreg.SetValueEx(odxkey32, "System.IsPinnedToNameSpaceTree", 0, _winreg.REG_DWORD, 0)  # Disable Explorer List-Pin
+        _winreg.CloseKey(odxkey32)
+        print "OneDrive 32-bit Windows Explorer pin successfully removed."
+    except (WindowsError, IOError):
+        print "Unable to modify OneDrive 32-bit Windows Explorer pin key. Deleted, or is the program not elevated?"
+        
+    try:
+        odxkey64 = _winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE, odxkey64, 0, _winreg.KEY_ALL_ACCESS)
+        _winreg.SetValueEx(odxkey64, "System.IsPinnedToNameSpaceTree", 0, _winreg.REG_DWORD, 0)  # Disable Explorer List-Pin
+        _winreg.CloseKey(odxkey64)
+        print "OneDrive 64-bit Windows Explorer pin successfully removed."
+    except (WindowsError, IOError):
+        print "Unable to modify OneDrive 64-bit Windows Explorer pin key. If your system is 32-bit, ignore this message. Deleted, or is the program not elevated?"
 
     onedrivesetup = os.path.join(os.environ['SYSTEMROOT'], "SysWOW64/OneDriveSetup.exe")
     if os.path.isfile(onedrivesetup):

--- a/run.py
+++ b/run.py
@@ -422,8 +422,8 @@ def modifyserviceregs(dwordval):
 
 def modifyonedrive(type):
     onedrivepath = r'SOFTWARE\Wow6432Node\Policies\Microsoft\Windows\OneDrive'  # Path to OneDrive key
-    odxpath32 = r'HKEY_CLASSES_ROOT\CLSID\{018D5C66-4533-4307-9B53-224DE2ED1FE6}' # Path to 32-bit Key
-    odxpath64 = r'HKEY_CLASSES_ROOT\Wow6432Node\CLSID\{018D5C66-4533-4307-9B53-224DE2ED1FE6}' # Path to 64-bit Key
+    odxpath32 = r'CLSID\{018D5C66-4533-4307-9B53-224DE2ED1FE6}' # Path to 32-bit Key
+    odxpath64 = r'Wow6432Node\CLSID\{018D5C66-4533-4307-9B53-224DE2ED1FE6}' # Path to 64-bit Key
 
     try:
         onedrivekey = _winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE, onedrivepath, 0, _winreg.KEY_ALL_ACCESS)
@@ -434,7 +434,7 @@ def modifyonedrive(type):
         print "Unable to modify OneDrive FileSync key. Deleted, or is the program not elevated?"
         
     try:
-        odxkey32 = _winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE, odxkey32, 0, _winreg.KEY_ALL_ACCESS)
+        odxkey32 = _winreg.OpenKey(_winreg.HKEY_CLASSES_ROOT, odxkey32, 0, _winreg.KEY_ALL_ACCESS)
         _winreg.SetValueEx(odxkey32, "System.IsPinnedToNameSpaceTree", 0, _winreg.REG_DWORD, 0)  # Disable Explorer List-Pin
         _winreg.CloseKey(odxkey32)
         print "OneDrive 32-bit Windows Explorer pin successfully removed."
@@ -442,7 +442,7 @@ def modifyonedrive(type):
         print "Unable to modify OneDrive 32-bit Windows Explorer pin key. Deleted, or is the program not elevated?"
         
     try:
-        odxkey64 = _winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE, odxkey64, 0, _winreg.KEY_ALL_ACCESS)
+        odxkey64 = _winreg.OpenKey(_winreg.HKEY_CLASSES_ROOT, odxkey64, 0, _winreg.KEY_ALL_ACCESS)
         _winreg.SetValueEx(odxkey64, "System.IsPinnedToNameSpaceTree", 0, _winreg.REG_DWORD, 0)  # Disable Explorer List-Pin
         _winreg.CloseKey(odxkey64)
         print "OneDrive 64-bit Windows Explorer pin successfully removed."


### PR DESCRIPTION
You forgot to comment your code at line 104.

Changes on 106 and 434 simply to differentiate from the two new OneDrive related tasks.

Lines 425-426 necessary for code on lines 436-450;
This code will change two registry entries, which will remove the OneDrive menu entry from File Explorer, as shown here:
http://betanews.com/wp-content/uploads/2015/08/onedrive.jpg

I am by no means a python programmer, but the syntax was simple enough I thought I would do, rather than request. The changes I proposed will get the job done, however, perhaps the best way to tackle this would be to create an array of values needing to be changed, and then looping that array (for-each?) through a single try/except, rather than repeating the code three times.

Thank you so much for all your hard work so far, it's a shame what's happened to privacy today...