### PR TITLE
Fix some typos in the issue reporting warning

### DIFF
--- a/dwt.py
+++ b/dwt.py
@@ -300,8 +300,8 @@ class MainPanel(wx.Panel):
         if self.onedrive_check.IsChecked():
             dwt_util.onedrive(undo=undo)
         logger.info("Done. It's recommended that you reboot as soon as possible for the full effect.")
-        logger.info(("If you feel something didn't work properly, please press the 'Report an issue"
-                      "button and follow the directions"))
+        logger.info(("If you feel something didn't work properly, please press the 'Report an issue'"
+                      " button and follow the directions"))
         console.Center()
         console.Show()
 


### PR DESCRIPTION
Just a quick typo, here is what it looked like before:
`13:00:46 INFO: If you feel something didn't work properly, please press the 'Report an issuebutton and follow the directions`

As you can see, there is a ' missing and a space missing between _issue_ and _button_