### PR TITLE
Set the checkbox to false when pressing no on the warning

### DIFF
--- a/dwt.py
+++ b/dwt.py
@@ -265,7 +265,7 @@ class MainPanel(wx.Panel):
                                     caption="Attention!", style=wx.YES_NO | wx.ICON_EXCLAMATION)
 
             if warn.ShowModal() == wx.ID_NO:
-                event.GetObject().SetValue(False)
+                event.GetEventObject().SetValue(False)
 
             warn.Destroy()
 


### PR DESCRIPTION
When clicking 'no' on the warning that says 'this may disable some features', an error occurs. The function that updates the checkbox is being called wrong.

The docs say that this should actually be ```getEventObject()```, not ```getObject()```

https://wxpython.org/docs/api/wx.Event-class.html#GetEventObject

![error](https://cloud.githubusercontent.com/assets/14277509/24685396/3a8250ca-197b-11e7-9c4b-71634fef5ca3.png)

@10se1ucgo 