### PR TITLE
Fix indentation error

### DIFF
--- a/dwt_util.py
+++ b/dwt_util.py
@@ -370,4 +370,4 @@ def dvr(undo):
                                  'AllowGameDVR', winreg.REG_DWORD, allow_game_dvr]}
 
     set_registry(dvr_keys)
-logger.info("Xbox DVR: successfully {action}".format(action=action))
+    logger.info("Xbox DVR: successfully {action}".format(action=action))


### PR DESCRIPTION
This fixes an indentation error at the end of the dwt_util.py file that caused the program not to launch.